### PR TITLE
Fix withCanSlide() to work before calling build() on Crossfader

### DIFF
--- a/library/src/main/java/com/mikepenz/crossfader/Crossfader.java
+++ b/library/src/main/java/com/mikepenz/crossfader/Crossfader.java
@@ -209,7 +209,6 @@ public class Crossfader {
 
         //create the cross fader container
         mCrossFadeSlidingPaneLayout = (CrossFadeSlidingPaneLayout) LayoutInflater.from(mContent.getContext()).inflate(R.layout.crossfader_base, container, false);
-        mCrossFadeSlidingPaneLayout.setCanSlide(mCanSlide);
         container.addView(mCrossFadeSlidingPaneLayout);
 
         //find the container layouts
@@ -245,6 +244,9 @@ public class Crossfader {
 
         //set the PanelSlideListener for the CrossFadeSlidingPaneLayout
         mCrossFadeSlidingPaneLayout.setPanelSlideListener(mPanelSlideListener);
+
+        //set the ability to slide
+        mCrossFadeSlidingPaneLayout.setCanSlide(mCanSlide);
 
         //define that we don't want a slider color
         mCrossFadeSlidingPaneLayout.setSliderFadeColor(Color.TRANSPARENT);

--- a/library/src/main/java/com/mikepenz/crossfader/Crossfader.java
+++ b/library/src/main/java/com/mikepenz/crossfader/Crossfader.java
@@ -209,6 +209,7 @@ public class Crossfader {
 
         //create the cross fader container
         mCrossFadeSlidingPaneLayout = (CrossFadeSlidingPaneLayout) LayoutInflater.from(mContent.getContext()).inflate(R.layout.crossfader_base, container, false);
+        mCrossFadeSlidingPaneLayout.setCanSlide(mCanSlide);
         container.addView(mCrossFadeSlidingPaneLayout);
 
         //find the container layouts


### PR DESCRIPTION
I have noticed that calling `withCanSlide(false)` before calling `build()` on the `Crossfader` doesn't work, since it applies it to `mCrossFadeSlidingPaneLayout` which doesn't exist until `build()` is called. 

This fix applies to the local var to `mCrossFadeSlidingPaneLayout` just after it's created as well.
